### PR TITLE
Added .hide() to revert the effects of .showInStatusBar().

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,11 @@ The easiest way to use this library is to add a label to the status bar:
 This will replace the status bar with a label that shows the current frames per second
 the application manages to draw.
 
+You can remove the label any time later:
+
+
+    FPSCounter.hide()
+
 If you'd like more control on how to display the frames, you can create a private
 `FPSCounter` instance and set a delegate
 

--- a/Sources/FPSStatusBarViewController.swift
+++ b/Sources/FPSStatusBarViewController.swift
@@ -86,10 +86,13 @@ internal class FPSStatusBarViewController: UIViewController, FPSCounterDelegate 
 
     // MARK: - Getting the shared status bar window
 
+    static var previouslyCreatedStatusBarWindow: UIWindow?
+    
     static var statusBarWindow: UIWindow = {
         let window = UIWindow()
         window.windowLevel = UIWindowLevelStatusBar
         window.rootViewController = FPSStatusBarViewController()
+        previouslyCreatedStatusBarWindow = window
         return window
     }()
 }
@@ -97,7 +100,7 @@ internal class FPSStatusBarViewController: UIViewController, FPSCounterDelegate 
 
 public extension FPSCounter {
 
-    // MARK: - Show FPS in the status bar
+    // MARK: - Show/Hide FPS in the status bar
 
     /// Add a label in the status bar that shows the applications current FPS.
     ///
@@ -120,5 +123,18 @@ public extension FPSCounter {
                 mode: mode ?? RunLoopMode.commonModes
             )
         }
+    }
+    
+    /// Removes the label that shows application current FPS from the status bar.
+    public class func hide() {
+        guard let window = FPSStatusBarViewController.previouslyCreatedStatusBarWindow else {
+            return
+        }
+        
+        if let controller = window.rootViewController as? FPSStatusBarViewController {
+            controller.fpsCounter.stopTracking()
+        }
+        
+        window.isHidden = true
     }
 }


### PR DESCRIPTION
This is small patch to be able to hide the FPS counter after you use `showInStatusBar`. I don't need anything elaborated, but I'd like to turn the thing off after I enabled it, without introducing another `FPSStatusBarViewController` just for that very case.