### PR TITLE
Avoid warnings on Xcode 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode10
+osx_image: xcode10.2
 language: objective-c
 before_script: 
   - pod lib lint --allow-warnings

--- a/FPSCounter.podspec
+++ b/FPSCounter.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "FPSCounter"
-  s.version      = "3.0.0"
+  s.version      = "3.1.0"
   s.homepage     = "https://github.com/konoma/fps-counter"
   s.summary      = "A small library to measure the frame rate of an iOS Application."
   s.description  = <<-DESC

--- a/FPSCounter.podspec
+++ b/FPSCounter.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   s.name         = "FPSCounter"
-  s.version      = "3.1.0"
+  s.version      = "4.0.0"
   s.homepage     = "https://github.com/konoma/fps-counter"
   s.summary      = "A small library to measure the frame rate of an iOS Application."
   s.description  = <<-DESC

--- a/FPSCounter.xcodeproj/project.pbxproj
+++ b/FPSCounter.xcodeproj/project.pbxproj
@@ -206,12 +206,12 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "konoma GmbH";
 				TargetAttributes = {
 					05371A1E1C88DEA0004C7A44 = {
 						CreatedOnToolsVersion = 7.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 					};
 					05371A361C88EA4C004C7A44 = {
 						CreatedOnToolsVersion = 7.2.1;
@@ -221,7 +221,7 @@
 			};
 			buildConfigurationList = 05371A191C88DEA0004C7A44 /* Build configuration list for PBXProject "FPSCounter" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -330,6 +330,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -389,6 +390,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -456,6 +458,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -476,6 +479,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.konoma.fps-counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/FPSCounter.xcodeproj/project.pbxproj
+++ b/FPSCounter.xcodeproj/project.pbxproj
@@ -458,7 +458,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -479,7 +479,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.konoma.fps-counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/FPSCounter.xcodeproj/project.pbxproj
+++ b/FPSCounter.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 					};
 					05371A361C88EA4C004C7A44 = {
 						CreatedOnToolsVersion = 7.2.1;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -379,7 +379,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -432,7 +432,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -458,7 +458,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -479,7 +479,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.konoma.fps-counter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -494,6 +494,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.konoma.fps-sample-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -508,6 +509,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ch.konoma.fps-sample-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/FPSCounter.xcodeproj/xcshareddata/xcschemes/FPSCounter.xcscheme
+++ b/FPSCounter.xcodeproj/xcshareddata/xcschemes/FPSCounter.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FPSCounter.xcodeproj/xcshareddata/xcschemes/Sample App.xcscheme
+++ b/FPSCounter.xcodeproj/xcshareddata/xcschemes/Sample App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ When you don't want to receive further updates, you can stop tracking:
 To install this library via [Carthage](https://github.com/Carthage/Carthage) add the
 following to your `Cartfile`:
 
-    github "konoma/fps-counter" ~> 3.0
+    github "konoma/fps-counter" ~> 4.0
 
 Then run the standard `carthage update` process.
 
@@ -65,7 +65,7 @@ Then run the standard `carthage update` process.
 To install this library via [CocoaPods](https://cocoapods.org) add the following to
 your `Podfile`:
 
-    pod 'FPSCounter', '~> 3.0'
+    pod 'FPSCounter', '~> 4.0'
 
 Then run the standard `pod update` process.
 

--- a/Sources/FPSStatusBarViewController.swift
+++ b/Sources/FPSStatusBarViewController.swift
@@ -130,7 +130,7 @@ public extension FPSCounter {
     // TODO: Handle old signature gracefully (showInStatusBar(_ application: ... ))
     // TODO: Update documentation afterwards
 
-    @objc public class func showInStatusBar(
+    @objc class func showInStatusBar(
         application: UIApplication = UIApplication.shared,
         runloop: RunLoop = .main,
         mode: RunLoop.Mode = .common
@@ -149,7 +149,7 @@ public extension FPSCounter {
 
     /// Removes the label that shows the current FPS from the status bar.
     ///
-    @objc public class func hide() {
+    @objc class func hide() {
         let window = FPSStatusBarViewController.statusBarWindow
 
         if let controller = window.rootViewController as? FPSStatusBarViewController {
@@ -160,7 +160,7 @@ public extension FPSCounter {
 
     /// Returns wether the FPS counter is currently visible or not.
     ///
-    @objc public class var isVisible: Bool {
+    @objc class var isVisible: Bool {
         return !FPSStatusBarViewController.statusBarWindow.isHidden
     }
 }


### PR DESCRIPTION
Some errors were raised when building on Xcode 10.2.
This PR make supporting Xcode 10.2.

<img width="379" alt="Screen Shot 2019-04-04 at 19 37 36" src="https://user-images.githubusercontent.com/147051/55549585-2b0f6300-5711-11e9-8f8a-eda6d43bc329.png">

Could you release newer version on CocoaPods?